### PR TITLE
Update to JEI 9.3.1 which doesn't require using JEI internals

### DIFF
--- a/src/main/java/net/mehvahdjukaar/jeed/jei/EffectRecipeCategory.java
+++ b/src/main/java/net/mehvahdjukaar/jeed/jei/EffectRecipeCategory.java
@@ -86,33 +86,6 @@ public class EffectRecipeCategory implements IRecipeCategory<EffectInfoRecipe> {
     }
 
     @Override
-    public void setRecipe(IRecipeLayoutBuilder builder, EffectInfoRecipe recipe, List<? extends IFocus<?>> focuses) {
-        IIngredientType<MobEffectInstance> type = recipe.getEffectIngredientType();
-
-        IRecipeSlotBuilder mainSlot = builder.addSlot(RecipeIngredientRole.INPUT, (recipeWidth - 18) / 2, yOffset + 3)
-                .setCustomRenderer(type, EffectInstanceRenderer.INSTANCE_SLOT)
-                .addIngredient(type, recipe.getEffect());
-
-        if (Jeed.EFFECT_BOX.get()) {
-            mainSlot.setBackground(effectBackground, -3, -3);
-        }
-
-        List<List<ItemStack>> slotContents = Arrays.asList(NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create());
-        List<ItemStack> compatible = recipe.getInputItems();
-
-        for (int slotId = 0; slotId < compatible.size(); slotId++) {
-            slotContents.get(slotId % slotContents.size()).add(compatible.get(slotId));
-        }
-
-        for (int slotId = 0; slotId < slotContents.size(); slotId++) {
-            int x = (int) (recipeWidth / 2 + (19f * ((slotId % 7) - 7 / 2f)));
-            int y = recipeHeight - 19 * (2 - (slotId / 7));
-            builder.addSlot(RecipeIngredientRole.OUTPUT, x, y)
-                    .addItemStacks(slotContents.get(slotId));
-        }
-    }
-
-    @Override
     public void draw(EffectInfoRecipe recipe, IRecipeSlotsView recipeSlotsView, PoseStack matrixStack, double mouseX, double mouseY) {
         int xPos = 0;
         int yPos = effectBackground.getHeight() + 4 + yOffset;
@@ -136,6 +109,33 @@ public class EffectRecipeCategory implements IRecipeCategory<EffectInfoRecipe> {
 
         for (int slotId = 0; slotId < 14; slotId++) {
             this.slotBackground.draw(matrixStack, (int) (recipeWidth / 2 + (19f * ((slotId % 7) - 7 / 2f))), recipeHeight - 19 * (1 + slotId / 7));
+        }
+    }
+
+    @Override
+    public void setRecipe(IRecipeLayoutBuilder builder, EffectInfoRecipe recipe, List<? extends IFocus<?>> focuses) {
+        IIngredientType<MobEffectInstance> type = recipe.getEffectIngredientType();
+
+        IRecipeSlotBuilder mainSlot = builder.addSlot(RecipeIngredientRole.INPUT, (recipeWidth - 18) / 2, yOffset + 3)
+                .setCustomRenderer(type, EffectInstanceRenderer.INSTANCE_SLOT)
+                .addIngredient(type, recipe.getEffect());
+
+        if (Jeed.EFFECT_BOX.get()) {
+            mainSlot.setBackground(effectBackground, -3, -3);
+        }
+
+        List<List<ItemStack>> slotContents = Arrays.asList(NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create(), NonNullList.create());
+        List<ItemStack> compatible = recipe.getInputItems();
+
+        for (int slotId = 0; slotId < compatible.size(); slotId++) {
+            slotContents.get(slotId % slotContents.size()).add(compatible.get(slotId));
+        }
+
+        for (int slotId = 0; slotId < slotContents.size(); slotId++) {
+            int x = (int) (recipeWidth / 2 + (19f * ((slotId % 7) - 7 / 2f)));
+            int y = recipeHeight - 19 * (2 - (slotId / 7));
+            builder.addSlot(RecipeIngredientRole.OUTPUT, x, y)
+                    .addItemStacks(slotContents.get(slotId));
         }
     }
 }

--- a/src/main/java/net/mehvahdjukaar/jeed/jei/JEIPlugin.java
+++ b/src/main/java/net/mehvahdjukaar/jeed/jei/JEIPlugin.java
@@ -4,6 +4,7 @@ import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.registration.*;
+import mezz.jei.api.runtime.IIngredientVisibility;
 import mezz.jei.api.runtime.IJeiRuntime;
 import net.mehvahdjukaar.jeed.Jeed;
 import net.mehvahdjukaar.jeed.jei.ingredient.EffectInstanceHelper;
@@ -41,6 +42,8 @@ public class JEIPlugin implements IModPlugin {
 
     @Override
     public void registerRecipes(IRecipeRegistration registry) {
+        JEI_INGREDIENT_VISIBILITY = registry.getIngredientVisibility();
+
         for (MobEffectInstance e : getEffectList()) {
 
             ResourceLocation name = e.getEffect().getRegistryName();
@@ -78,6 +81,7 @@ public class JEIPlugin implements IModPlugin {
     //TODO: register keyword
 
     public static IJeiRuntime JEI_RUNTIME;
+    public static IIngredientVisibility JEI_INGREDIENT_VISIBILITY;
 
     @Override
     public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {

--- a/src/main/java/net/mehvahdjukaar/jeed/jei/JeiStuff.java
+++ b/src/main/java/net/mehvahdjukaar/jeed/jei/JeiStuff.java
@@ -2,7 +2,6 @@ package net.mehvahdjukaar.jeed.jei;
 
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.runtime.IIngredientVisibility;
-import mezz.jei.api.runtime.IJeiRuntime;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.List;
@@ -11,8 +10,7 @@ import java.util.stream.Collectors;
 public class JeiStuff {
 
     public static List<ItemStack> getInputItems(List<ItemStack> inputItems) {
-        IJeiRuntime jeiRuntime = JEIPlugin.JEI_RUNTIME;
-        IIngredientVisibility ingredientVisibility = jeiRuntime.getIngredientVisibility();
+        IIngredientVisibility ingredientVisibility = JEIPlugin.JEI_INGREDIENT_VISIBILITY;
         return inputItems.stream()
                 .filter(s -> !s.isEmpty())
                 .filter(s -> ingredientVisibility.isIngredientVisible(VanillaTypes.ITEM, s))

--- a/src/main/java/net/mehvahdjukaar/jeed/jei/JeiStuff.java
+++ b/src/main/java/net/mehvahdjukaar/jeed/jei/JeiStuff.java
@@ -1,7 +1,8 @@
 package net.mehvahdjukaar.jeed.jei;
 
-import mezz.jei.Internal;
-import mezz.jei.ingredients.IngredientFilter;
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.runtime.IIngredientVisibility;
+import mezz.jei.api.runtime.IJeiRuntime;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.List;
@@ -10,9 +11,12 @@ import java.util.stream.Collectors;
 public class JeiStuff {
 
     public static List<ItemStack> getInputItems(List<ItemStack> inputItems) {
-        IngredientFilter filter = Internal.getIngredientFilter();
-        return inputItems.stream().filter(s -> !s.isEmpty())
-                .filter(filter::isIngredientVisible).collect(Collectors.toList());
+        IJeiRuntime jeiRuntime = JEIPlugin.JEI_RUNTIME;
+        IIngredientVisibility ingredientVisibility = jeiRuntime.getIngredientVisibility();
+        return inputItems.stream()
+                .filter(s -> !s.isEmpty())
+                .filter(s -> ingredientVisibility.isIngredientVisible(VanillaTypes.ITEM, s))
+                .collect(Collectors.toList());
 
     }
 

--- a/src/main/java/net/mehvahdjukaar/jeed/jei/ingredient/EffectInstanceHelper.java
+++ b/src/main/java/net/mehvahdjukaar/jeed/jei/ingredient/EffectInstanceHelper.java
@@ -61,6 +61,18 @@ public class EffectInstanceHelper implements IIngredientHelper<MobEffectInstance
     }
 
     @Override
+    public ResourceLocation getResourceLocation(MobEffectInstance ingredient) {
+        ResourceLocation registryName = ingredient.getEffect().getRegistryName();
+        if (registryName == null) {
+            String ingredientInfo = this.getErrorInfo(ingredient);
+            throw new IllegalStateException("effect.getRegistryName() returned null for: " + ingredientInfo);
+        } else {
+            return registryName;
+        }
+    }
+
+    @SuppressWarnings("removal")
+    @Override
     public String getModId(MobEffectInstance ingredient) {
         ResourceLocation registryName = ingredient.getEffect().getRegistryName();
         if (registryName == null) {
@@ -71,6 +83,7 @@ public class EffectInstanceHelper implements IIngredientHelper<MobEffectInstance
         }
     }
 
+    @SuppressWarnings("removal")
     @Override
     public String getResourceId(MobEffectInstance ingredient) {
         ResourceLocation registryName = ingredient.getEffect().getRegistryName();

--- a/src/main/java/net/mehvahdjukaar/jeed/jei/ingredient/EffectInstanceRenderer.java
+++ b/src/main/java/net/mehvahdjukaar/jeed/jei/ingredient/EffectInstanceRenderer.java
@@ -23,7 +23,6 @@ import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -44,26 +43,21 @@ public class EffectInstanceRenderer implements IIngredientRenderer<MobEffectInst
     }
 
     @Override
-    public void render(PoseStack matrixStack, int xPosition, int yPosition, @Nullable MobEffectInstance effectInstance) {
-
-        if (effectInstance != null ) {
-
-            MobEffect effect = effectInstance.getEffect();
+    public void render(PoseStack matrixStack, MobEffectInstance effectInstance) {
+        MobEffect effect = effectInstance.getEffect();
 
 
-            MobEffectTextureManager potionspriteuploader = MC.getMobEffectTextures();
-            TextureAtlasSprite textureatlassprite = potionspriteuploader.get(effect);
+        MobEffectTextureManager potionspriteuploader = MC.getMobEffectTextures();
+        TextureAtlasSprite textureatlassprite = potionspriteuploader.get(effect);
 
 
-            RenderSystem.clearColor(1.0F, 1.0F,1.0F,1.0F);
-            RenderSystem.setShader(GameRenderer::getPositionTexShader);
-            RenderSystem.setShaderTexture(0, textureatlassprite.atlas().location());
-            int o = offset ? -1 : (Jeed.REI ? 3 : 0);
-            GuiComponent.blit(matrixStack, xPosition + o, yPosition+ o, 0, 18, 18, textureatlassprite);
+        RenderSystem.clearColor(1.0F, 1.0F,1.0F,1.0F);
+        RenderSystem.setShader(GameRenderer::getPositionTexShader);
+        RenderSystem.setShaderTexture(0, textureatlassprite.atlas().location());
+        int o = offset ? -1 : (Jeed.REI ? 3 : 0);
+        GuiComponent.blit(matrixStack, o, o, 0, 18, 18, textureatlassprite);
 
-            RenderSystem.applyModelViewMatrix();
-
-        }
+        RenderSystem.applyModelViewMatrix();
     }
 
 
@@ -151,5 +145,13 @@ public class EffectInstanceRenderer implements IIngredientRenderer<MobEffectInst
         return tooltip;
     }
 
+    @Override
+    public int getWidth() {
+        return offset ? 16 : 18;
+    }
 
+    @Override
+    public int getHeight() {
+        return offset ? 16 : 18;
+    }
 }

--- a/src/main/java/net/mehvahdjukaar/jeed/jei/plugins/InventoryScreenHandler.java
+++ b/src/main/java/net/mehvahdjukaar/jeed/jei/plugins/InventoryScreenHandler.java
@@ -2,13 +2,12 @@ package net.mehvahdjukaar.jeed.jei.plugins;
 
 import mezz.jei.api.gui.handlers.IGuiContainerHandler;
 import mezz.jei.api.recipe.IFocus;
-import mezz.jei.gui.Focus;
-import mezz.jei.input.ClickedIngredient;
-import mezz.jei.input.IClickedIngredient;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.runtime.IJeiRuntime;
+import mezz.jei.api.runtime.IRecipesGui;
 import net.mehvahdjukaar.jeed.jei.JEIPlugin;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen;
-import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import org.jetbrains.annotations.Nullable;
@@ -57,11 +56,11 @@ public class InventoryScreenHandler <C extends AbstractContainerMenu, T extends 
     }
 
     public static void onClickedEffect(MobEffectInstance effect, double x, double y, int button){
+        IJeiRuntime jeiRuntime = JEIPlugin.JEI_RUNTIME;
+        IFocus<MobEffectInstance> focus = jeiRuntime.createFocus(RecipeIngredientRole.OUTPUT, JEIPlugin.EFFECT, effect);
 
-        Rect2i slotArea = new Rect2i((int)x, (int)y, 16, 16);
-        IClickedIngredient<?> clicked = ClickedIngredient.create(effect, slotArea);
-
-        JEIPlugin.JEI_RUNTIME.getRecipesGui().show(new Focus<Object>(IFocus.Mode.OUTPUT, clicked.getValue()));
+        IRecipesGui recipesGui = jeiRuntime.getRecipesGui();
+        recipesGui.show(focus);
     }
 
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -57,3 +57,9 @@ A JEI plugin that displays all status effects and how to obtain them
     versionRange="[1.18.0,1.19)"
     ordering="NONE"
     side="BOTH"
+[[dependencies.jeed]]
+    modId="jei"
+    mandatory=false
+    versionRange="[9.3.0,)"
+    ordering="NONE"
+    side="CLIENT"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -60,6 +60,6 @@ A JEI plugin that displays all status effects and how to obtain them
 [[dependencies.jeed]]
     modId="jei"
     mandatory=false
-    versionRange="[9.3.0,)"
+    versionRange="[9.3.1,)"
     ordering="NONE"
     side="CLIENT"


### PR DESCRIPTION
Hello,

This mod breaks on the JEI 9.3.0 update because it uses internal classes in JEI.
I added some methods to the API in JEI 9.3.1, so that this mod doesn't need to use JEI internal classes any more.